### PR TITLE
fix: setIntervalの戻り値型をNode.js環境に対応 (#28)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,7 +172,7 @@ function App() {
       demoIntervalRef.current = setInterval(() => {
         const demoData = generateDemoData();
         handleDataReceived(demoData);
-      }, 1000); // 0.5秒ごとにデータ生成
+      }, 1000) as unknown as number; // 型アサーションを追加
     } else if (demoIntervalRef.current) {
       clearInterval(demoIntervalRef.current);
       demoIntervalRef.current = null;


### PR DESCRIPTION
Node.js環境とブラウザ環境でsetIntervalの戻り値型が異なる問題を解決。
setIntervalの戻り値に`as unknown as number`の型アサーションを追加し、 型エラーを回避。

Issue: #28